### PR TITLE
General styling to main page

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "prettier-plugin-go-template": "0.0.15",
     "prettier-plugin-tailwindcss": "^0.5.9",
     "tailwind-bootstrap-grid": "^5.1.0",
-    "tailwindcss": "^3.4.0"
+    "tailwindcss": "^3.4.1"
   }
 }

--- a/themes/hugoplate/assets/js/main.js
+++ b/themes/hugoplate/assets/js/main.js
@@ -18,7 +18,7 @@
   // ----------------------------------------
   new Swiper(".testimonial-slider", {
     spaceBetween: 24,
-    loop: true,
+    loop: false,
     pagination: {
       el: ".testimonial-slider-pagination",
       type: "bullets",
@@ -28,9 +28,12 @@
       768: {
         slidesPerView: 2,
       },
-      992: {
-        slidesPerView: 3,
+      900: {
+        slidesPerView:3
       },
+      1100: {
+        slidesPerView: 5,
+      }
     },
   });
 })();

--- a/themes/hugoplate/layouts/index.html
+++ b/themes/hugoplate/layouts/index.html
@@ -94,7 +94,7 @@
                     <div class="swiper-slide">
                       <div
                         class="bg-theme-light dark:bg-darkmode-theme-light rounded-lg px-7 py-10">
-                        {{/*  <div class="text-dark dark:text-white">
+                        {{/*<div class="text-dark dark:text-white">
                           <svg
                             width="33"
                             height="20"
@@ -108,19 +108,11 @@
                         </div>
                         <blockquote class="mt-8">
                           {{ .content | markdownify }}
-                        </blockquote>  */}}
-                        <div class="mt-7 flex items-center">
+                        </blockquote>/*/}}
+                        <div class="flex items-center">
                           <div class="text-dark dark:text-white">
                             {{ partial "image" (dict "Src" .avatar "Class" "rounded-small" "Alt" .name) }}
                           </div>
-                          {{/*  <div class="ml-4">
-                            <h3 class="h5 font-primary font-semibold">
-                              {{ .name }}
-                            </h3>
-                            <p class="text-dark dark:text-white">
-                              {{ .designation | markdownify }}
-                            </p>
-                          </div>  */}}
                         </div>
                       </div>
                     </div>

--- a/themes/hugoplate/layouts/partials/essentials/footer.html
+++ b/themes/hugoplate/layouts/partials/essentials/footer.html
@@ -6,8 +6,9 @@
         <a
           class="navbar-brand inline-block"
           href="{{ site.Home.RelPermalink }}">
-          {{ partial "logo" }}
+          {{ partial "logo" }}© 
         </a>
+        <div class="whitespace-nowrap text-sm mt-3">Lets build intelligent radios together.</div>
       </div>
       <div class="lg:col-6 mb-8 text-center lg:mb-0">
         <ul>
@@ -47,11 +48,11 @@
       </div>
     </div>
   </div>
-  <div class="border-border dark:border-darkmode-border border-t py-7">
+  {{/*<div class="border-border dark:border-darkmode-border border-t py-7">
     <div class="text-light dark:text-darkmode-light container text-center">
       <p>
         {{ site.Params.copyright | markdownify }}
       </p>
     </div>
-  </div>
+  </div>*/}}
 </footer>

--- a/themes/hugoplate/layouts/partials/essentials/header.html
+++ b/themes/hugoplate/layouts/partials/essentials/header.html
@@ -36,13 +36,14 @@
         {{ $pageURL:= $currentPage.Permalink | absLangURL }}
         {{ $active := eq $menuURL $pageURL }}
         {{ if .HasChildren }}
-          <li class="nav-item nav-dropdown group relative">
+          <li class="nav-item nav-dropdown group relative ">
             <span
+              style="font-family: 'Open Sans', sans-serif; font-weight: 500;"
               class="nav-link {{ range .Children }}
                 {{ $childURL := .URL | absLangURL }}
                 {{ $active := eq $childURL $pageURL }}
                 {{ if $active }}active{{ end }}
-              {{ end }} inline-flex items-center">
+              {{ end }} inline-flex items-center cursor-pointer">
               {{ .Name }}
               <svg class="h-4 w-4 fill-current" viewBox="0 0 20 20">
                 <path
@@ -50,15 +51,16 @@
               </svg>
             </span>
             <ul
-              class="nav-dropdown-list lg:group-hover:visible lg:group-hover:opacity-100">
+              class="nav-dropdown-list lg:group-hover:visible lg:group-hover:opacity-100 hover:bg-dark gray-500">
               {{ range .Children }}
                 {{ $childURL := .URL | absLangURL }}
                 {{ $active := eq $childURL $pageURL }}
                 <li class="nav-dropdown-item">
                   <a
-                    class="nav-dropdown-link {{ if $active }}
+                    style="font-family: 'Open Sans', sans-serif; font-weight: 500;"
+                    class="nav-dropdown-link whitespace-nowrap {{ if $active }}
                       active
-                    {{- end -}}"
+                    {{- end -}} "
                     {{ if findRE `^http` .URL }}
                       target="_blank" rel="noopener"
                     {{ end }}
@@ -77,8 +79,9 @@
             </ul>
           </li>
         {{ else }}
-          <li class="nav-item">
+          <li class="nav-item ">
             <a
+              style="font-family: 'Open Sans', sans-serif; font-weight: 400"
               class="nav-link {{ if $active }}active{{- end -}}"
               {{ if findRE `^http` .URL }}
                 target="_blank" rel="noopener"


### PR DESCRIPTION
- Made navbar links font thinner and added hover effect for navbar dropdown. 
<img width="600" alt="Screenshot 2024-01-08 at 4 51 52 PM" src="https://github.com/qoherent/qoherentnew/assets/102482696/08da1ceb-5f06-4e98-9308-5618ecfc9f94">

- Supported tiles were changed from 3 -> 5 (responsive based on screen width) and loop was turned off. 
<img width="600" alt="Screenshot 2024-01-08 at 4 53 19 PM" src="https://github.com/qoherent/qoherentnew/assets/102482696/7d819a80-49d9-4844-88a9-ccf2175050d1">

- Footer break was taken out and copyright text was moved adjacent to company logo. 
<img width="600" alt="Screenshot 2024-01-08 at 4 54 01 PM" src="https://github.com/qoherent/qoherentnew/assets/102482696/c71a5706-8562-4759-b67a-89d0afd07aa6">

