### PR TITLE
Modified article styling

### DIFF
--- a/content/english/blog/2409-SRS-SC2430-X410-guide/index.md
+++ b/content/english/blog/2409-SRS-SC2430-X410-guide/index.md
@@ -82,12 +82,23 @@ The following prerequisites are required to complete this guide:
 * A valid license from the relevant regulatory authority is required for any over-the-air RF transmissions. ***==This guide assumes that you have obtained the necessary license and fulfilled all related requirements.==***
 * An internet connection is required for the host machine to complete speed testing and benchmarks.
 
-\* *The computer impacts gNodeB performance and configuration such as bandwidth it can support. For more details on computer requirements, see **__[this guide](https://docs.srsran.com/projects/4g/en/latest/app_notes/source/hw_packs/source/index.html)__** from SRS*
+<div class="fine-print">
 
-\*\* *SFP+ NIC's are compatible with an appropriate adapter. [Please see the Ettus support page.](https://kb.ettus.com/X410#Guidance_on_SFP.2B_Adapters_for_Fiber_Connectivity_on_NI_Ettus_USRP_X410)*
-
+*\* The computer impacts gNodeB performance and configuration such as bandwidth it can support. For more details on computer requirements, see **__[this guide](https://docs.srsran.com/projects/4g/en/latest/app_notes/source/hw_packs/source/index.html)__** from SRS*  
+*\*\* SFP+ NIC's are compatible with an appropriate adapter. [Please see the Ettus support page.](https://kb.ettus.com/X410#Guidance_on_SFP.2B_Adapters_for_Fiber_Connectivity_on_NI_Ettus_USRP_X410)*  
 *\*\*\* Other USRP's such as the B210 or X310 may be used with some extra configuration and timing controls.*
 
+</div>
+
+<style>
+  .fine-print p em, .fine-print {
+    font-size: 0.75rem; 
+    color: #ffffff;
+    line-height: 1.15;
+    font-style: normal;
+    font-weight: bold;
+  }
+</style>
 
 ## Simplified USRP X410 Setup instructions
 
@@ -402,9 +413,9 @@ Note: You can change the password in ***Account*** Menu.
 To add subscriber information, you can do WebUI operations in the following order: 
 
 
-1. Go to `Subscriber `Menu. 
+1. Go to `Subscriber` Menu. 
 2. Click `+` Button to add a new subscriber. Fill the IMSI, security context **(K, OPc, AMF), and APN** of the subscriber. 
-3. Click the `SAVE `Button
+3. Click the `SAVE` Button
 
  ![](attachments/b9d09e44-69b8-4add-a310-f0c4502a97fd.png)
 

--- a/content/english/blog/2409-SRS-SC2430-X410-guide/index.md
+++ b/content/english/blog/2409-SRS-SC2430-X410-guide/index.md
@@ -92,9 +92,9 @@ The following prerequisites are required to complete this guide:
 
 <style>
   .fine-print p em, .fine-print {
-    font-size: 0.75rem; 
+    font-size: 0.875rem; 
     color: #ffffff;
-    line-height: 1.15;
+    line-height: 1.2;
     font-style: normal;
     font-weight: bold;
   }

--- a/content/english/pages/elements.md
+++ b/content/english/pages/elements.md
@@ -114,7 +114,129 @@ This is a simple info.
 This is a simple warning.
 {{< /notice >}}
 
+#### Adding a custom notice
+
+The following code:
+
+```bash
+{{</* notice "Notice title" */>}}
+This is a demo of a custom notice.
+{{</* /notice */>}}
+
+<style>
+    .notice.Notice.title {
+        color: #1b83e2;
+        border-color: currentColor;
+    }
+</style>
+
+<script>
+document.querySelector('.notice.Notice.title .notice-head svg').outerHTML = `
+<svg width="20" height="20" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM9.25 3.75C9.25 4.44036 8.69036 5 8 5C7.30964 5 6.75 4.44036 6.75 3.75C6.75 3.05964 7.30964 2.5 8 2.5C8.69036 2.5 9.25 3.05964 9.25 3.75ZM12 8H9.41901L11.2047 13H9.081L8 9.97321L6.91901 13H4.79528L6.581 8H4V6H12V8Z" fill="currentColor"/>
+</svg>
+`;
+</script>
+
+```
+Creates the following notice: 
+
+{{<notice "Notice title" >}}
+This is a demo of a custom notice.
+{{< /notice >}}
+
+<style>
+    .notice.Notice.title {
+        color: #1b83e2;
+        border-color: currentColor;
+    }
+</style>
+
+<script>
+document.querySelector('.notice.Notice.title .notice-head svg').outerHTML = `
+<svg width="20" height="20" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M16 8C16 12.4183 12.4183 16 8 16C3.58172 16 0 12.4183 0 8C0 3.58172 3.58172 0 8 0C12.4183 0 16 3.58172 16 8ZM9.25 3.75C9.25 4.44036 8.69036 5 8 5C7.30964 5 6.75 4.44036 6.75 3.75C6.75 3.05964 7.30964 2.5 8 2.5C8.69036 2.5 9.25 3.05964 9.25 3.75ZM12 8H9.41901L11.2047 13H9.081L8 9.97321L6.91901 13H4.79528L6.581 8H4V6H12V8Z" fill="currentColor"/>
+</svg>
+`;
+</script>
+
+
+Note: The class selector of the CSS must target the `notice.{notice_title}`. For the javascript, it will always be `.notice.{notice_title} .notice-head svg`. 
+
+Note 2: The `fill` property of the SVG must be set to `currentColor` as shown above. The `width` and `height` should both be `20` to stay in line with the other notices.
+
 <hr>
+
+### Customizing Image Size in Markdown
+
+To customize the image size in Markdown, we need to make use of HTML. To accomplish this, we can do:
+
+```HTML
+<img src="attachments/sc2430-usrp-x410.png" alt="SCM2430 + USRP X410 System" width="700" height="300"/>
+```
+
+Where the width and height can be specified. If you need to center as well you would do: 
+
+```HTML
+<p align="center">
+  <img src="attachments/sc2430-usrp-x410.png" alt="SCM2430 + USRP X410 System" width="700" height="300"/>
+</p>
+```
+
+This would for example, be replacing something like `![SCM2430 + USRP X410 System](attachments/sc2430-usrp-x410.png)`
+
+### Modifying fine print style
+
+To modify the style of fine print in Markdown, we need to use inline HTML. 
+
+This is an example of the standard rendered: 
+
+*\* The computer impacts gNodeB performance and configuration such as bandwidth it can support. For more details on computer requirements, see **__[this guide](https://docs.srsran.com/projects/4g/en/latest/app_notes/source/hw_packs/source/index.html)__** from SRS*  
+*\*\* SFP+ NIC's are compatible with an appropriate adapter. [Please see the Ettus support page.](https://kb.ettus.com/X410#Guidance_on_SFP.2B_Adapters_for_Fiber_Connectivity_on_NI_Ettus_USRP_X410)*  
+*\*\*\* Other USRP's such as the B210 or X310 may be used with some extra configuration and timing controls.*
+
+Modifying and adding inline HTML/CSS like so:
+
+```HTML
+<div class="fine-print">
+
+*\* The computer impacts gNodeB performance and configuration such as bandwidth it can support. For more details on computer requirements, see **__[this guide](https://docs.srsran.com/projects/4g/en/latest/app_notes/source/hw_packs/source/index.html)__** from SRS*  
+*\*\* SFP+ NIC's are compatible with an appropriate adapter. [Please see the Ettus support page.](https://kb.ettus.com/X410#Guidance_on_SFP.2B_Adapters_for_Fiber_Connectivity_on_NI_Ettus_USRP_X410)*  
+*\*\*\* Other USRP's such as the B210 or X310 may be used with some extra configuration and timing controls.*
+
+</div>
+
+<style>
+  .fine-print p em, .fine-print {
+    font-size: 0.75rem; 
+    color: #ffffff;
+    line-height: 1.15;
+    font-style: normal;
+    font-weight: bold;
+  }
+</style>
+
+```
+
+Would instead render this as: 
+
+<div class="fine-print">
+
+*\* The computer impacts gNodeB performance and configuration such as bandwidth it can support. For more details on computer requirements, see **__[this guide](https://docs.srsran.com/projects/4g/en/latest/app_notes/source/hw_packs/source/index.html)__** from SRS*  
+*\*\* SFP+ NIC's are compatible with an appropriate adapter. [Please see the Ettus support page.](https://kb.ettus.com/X410#Guidance_on_SFP.2B_Adapters_for_Fiber_Connectivity_on_NI_Ettus_USRP_X410)*  
+*\*\*\* Other USRP's such as the B210 or X310 may be used with some extra configuration and timing controls.*
+
+</div>
+
+<style>
+  .fine-print p em, .fine-print {
+    font-size: 0.75rem; 
+    color: #ffffff;
+    line-height: 1.15;
+    font-style: normal;
+    font-weight: bold;
+  }
+</style>
 
 ### Tab
 

--- a/themes/hugoplate/assets/js/copybutton.js
+++ b/themes/hugoplate/assets/js/copybutton.js
@@ -1,0 +1,40 @@
+function addCopyButtonToCodeBlocks() {
+    const codeBlocks = document.querySelectorAll(
+      'pre > code[class^="language-"]'
+    );
+    const copyIcon = '<i class="fas fa-copy"></i>';
+    const copiedIcon = '<i class="fas fa-check"></i>';
+  
+    codeBlocks.forEach((codeBlock) => {
+      codeBlock.style.backgroundColor = "#272822";
+  
+      const copyButton = document.createElement("button");
+      copyButton.classList.add("btn", "copy-code-button");
+      copyButton.style.background = "none";
+      copyButton.style.border = "none";
+      copyButton.style.color = "#d1d1d1";
+      copyButton.style.fontSize = "100%"; 
+      copyButton.style.cursor = "pointer";
+      copyButton.style.position = "absolute";
+      copyButton.style.top = "2px";
+      copyButton.style.right = "3px";
+      copyButton.innerHTML = copyIcon;
+  
+      copyButton.addEventListener("click", () => {
+        const codeToCopy = codeBlock.innerText;
+        navigator.clipboard.writeText(codeToCopy);
+  
+        copyButton.innerHTML = copiedIcon;
+        setTimeout(() => {
+          copyButton.innerHTML = copyIcon;
+        }, 1500);
+      });
+  
+      const preElement = codeBlock.parentElement;
+      preElement.style.position = "relative"; 
+      preElement.appendChild(copyButton);
+    });
+  }
+  
+  document.addEventListener("DOMContentLoaded", addCopyButtonToCodeBlocks);
+  

--- a/themes/hugoplate/assets/scss/base.scss
+++ b/themes/hugoplate/assets/scss/base.scss
@@ -61,7 +61,18 @@ strong {
 }
 
 code {
-  @apply after:content-none before:content-none dark:text-qoherentblack;
+  @apply dark:text-qoherentblack;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgb(29, 32, 42);
+  padding: 3px 4px;
+  color: rgb(206, 145, 120);
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 80%;
+}
+
+.notice {
+  @apply rounded-lg;
 }
 
 blockquote > p {

--- a/themes/hugoplate/assets/scss/base.scss
+++ b/themes/hugoplate/assets/scss/base.scss
@@ -64,11 +64,19 @@ strong {
   @apply dark:text-qoherentblack;
   border-radius: 4px;
   border: 1px solid rgba(255, 255, 255, 0.1) !important;
-  background: rgb(29, 32, 42) !important;
+  background: #171717 !important;
   padding: 3px 4px;
-  color: rgb(206, 145, 120) !important;
+  color: rgb(221, 135, 101) !important;
   font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
   font-size: 80%;
+}
+
+.btn.copy-code-button:hover i.fas.fa-copy::before{
+  color: #884da0 !important;
+}
+
+.btn.copy-code-button:hover i.fas.fa-check::before{
+  color: #884da0 !important;
 }
 
 .notice {

--- a/themes/hugoplate/assets/scss/base.scss
+++ b/themes/hugoplate/assets/scss/base.scss
@@ -60,14 +60,14 @@ strong {
   @apply font-semibold;
 }
 
-code {
+:not(pre) > code {
   @apply dark:text-qoherentblack;
   border-radius: 4px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgb(29, 32, 42);
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  background: rgb(29, 32, 42) !important;
   padding: 3px 4px;
-  color: rgb(206, 145, 120);
-  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  color: rgb(206, 145, 120) !important;
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
   font-size: 80%;
 }
 

--- a/themes/hugoplate/assets/scss/components.scss
+++ b/themes/hugoplate/assets/scss/components.scss
@@ -59,7 +59,7 @@ main {
   @apply prose-p:text-base prose-p:text-text prose-p:dark:text-darkmode-text;
   @apply prose-blockquote:rounded-lg prose-blockquote:border prose-blockquote:border-l-[10px] prose-blockquote:border-primary prose-blockquote:bg-theme-light prose-blockquote:px-8 prose-blockquote:py-10 prose-blockquote:font-secondary prose-blockquote:text-2xl prose-blockquote:not-italic prose-blockquote:text-dark prose-blockquote:dark:border-darkmode-primary prose-blockquote:dark:bg-darkmode-theme-light prose-blockquote:dark:text-darkmode-light;
   @apply prose-pre:rounded-lg prose-pre:bg-theme-light prose-pre:dark:bg-darkmode-theme-light;
-  @apply prose-code:px-0.5 prose-code:dark:text-darkmode-light prose-code:dark:bg-qoherentblack prose-code:after:content-none prose-code:before:content-none;
+  @apply prose-code:dark:text-darkmode-light prose-code:dark:bg-qoherentblack prose-code:after:content-none prose-code:before:content-none;
   @apply prose-strong:text-dark prose-strong:dark:text-darkmode-text;
   @apply prose-a:text-text prose-a:underline hover:prose-a:text-primary prose-a:dark:text-darkmode-text hover:prose-a:dark:text-darkmode-primary;
   @apply prose-li:text-text prose-li:dark:text-darkmode-text;

--- a/themes/hugoplate/layouts/_default/baseof.html
+++ b/themes/hugoplate/layouts/_default/baseof.html
@@ -13,6 +13,12 @@
 
     <!-- style (always cache it) -->
     {{ partialCached "essentials/style.html" . }}
+    {{ with resources.Get "js/copybutton.js" }}
+    {{ $minifiedScript := . | minify | fingerprint }}
+    <script src="{{ $minifiedScript.Permalink }}" integrity="{{ $minifiedScript.Data.Integrity }}" defer></script>
+    {{ else }}
+        {{ errorf "copybutton.js not found in assets/js/" }}
+    {{ end }}
   </head>
 
   <body>

--- a/themes/hugoplate/layouts/blog/single.html
+++ b/themes/hugoplate/layouts/blog/single.html
@@ -10,7 +10,7 @@
               {{ partial "image" (dict "Src" $image "Alt" .Title "Class" "w-full rounded") }}
             </div>
           {{ end }}
-          <h1 class="h2 mb-4">
+          <h1 class="mb-4 text-center">
             {{ .Title }}
           </h1>
           <ul class="mb-4">


### PR DESCRIPTION
- Modified title to be larger and centered: 

![Screenshot 2024-09-10 at 2 16 13 PM](https://github.com/user-attachments/assets/5fbb1473-1875-4444-9628-7456790ceec3)

- Image resizing we talked a bit about already, but there's an example in `elements.md` now

![Screenshot 2024-09-10 at 2 17 32 PM](https://github.com/user-attachments/assets/82d1cb22-fc56-40be-8022-0fb193bf24e0)

- Fine print needed to use HTML/CSS, the one in the article was modified to look like, lmk your thoughts: 

![Screenshot 2024-09-10 at 2 18 36 PM](https://github.com/user-attachments/assets/892c3115-1220-4690-935a-6b363f512e47)

- Weird lines removed from code blocks, and copy button added to code

![Screenshot 2024-09-10 at 2 19 00 PM](https://github.com/user-attachments/assets/2ca095f5-dc76-48ab-8174-05b1d9157e1d)

- When you hover over it, it turns black

![Screenshot 2024-09-10 at 2 23 50 PM](https://github.com/user-attachments/assets/8491ad75-c3c7-4b13-84e6-dbbe022a4b85)

- When you click it shows a checkmark to reflect that its copied

![Screenshot 2024-09-10 at 2 25 08 PM](https://github.com/user-attachments/assets/c9c151f7-32df-4a41-90bd-73484a6d056d)

- Inline code updated to reflect style on Outline and pop more 

![Screenshot 2024-09-10 at 2 22 58 PM](https://github.com/user-attachments/assets/90807b32-c32e-423e-8229-b27f8f7c5059)

- Notices are rounded as they were in the original hugoplate theme (12px) 

![Screenshot 2024-09-10 at 2 25 49 PM](https://github.com/user-attachments/assets/20f8a18e-30f9-4bf2-b741-e7530d6e06f4)

- Custom notice instructions added to `elements.md`, this can also be used to rename any of the original notices