### PR TITLE
removing hubspot forms from home page and ria hub page

### DIFF
--- a/content/english/pages/radiointelligenceapps-riahub.md
+++ b/content/english/pages/radiointelligenceapps-riahub.md
@@ -27,26 +27,4 @@ _**Radio Intelligence Apps Hub (RIA Hub)**_ by Qoherent is an AI development pla
 - Open Source and community libraries.
 - Synthesizers, recordings, pre-trained models, and API's for accelerating the time to prototype.
 
-
-<p class="text">Sign up for our early access program below:</p>
-<br>
-<div class="form-div">
-<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
-<script>
-hbspt.forms.create({
-    region: "na1",
-    portalId: "45248873",
-    formId: "1fba45f6-b9bc-44ac-b908-8ac42274ae72"
-});
-</script>
-</div>
-
-<style>
-    .form-div {
-        width: 80%;
-        margin: auto;
-        max-width: 500px;
-    }
-</style>
-
 <p class="text">RIA Hub is built on top of the <a href="https://github.com/qoherent/ria">RIA project</a> and <a href="https://github.com/go-gitea/gitea">Gitea</a>.</p>

--- a/themes/hugoplate/layouts/index.html
+++ b/themes/hugoplate/layouts/index.html
@@ -14,16 +14,6 @@
                     <p class="mb-4 text-center"> 
                         {{ .content | markdownify }}
                     </p>
-                      <div class="form-div w-[80%] mx-auto max-w-lg">
-                        <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
-                        <script>
-                          hbspt.forms.create({
-                            region: "na1",
-                            portalId: "45248873",
-                            formId: "39c3ea3e-3194-4d06-a9a6-f54201223e81"
-                          });
-                        </script>
-                      </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Removing the Hubspot forms from the Qoherent website's [home page](https://qoherent.ai/) and [RIA Hub Page](https://qoherent.ai/radiointelligenceapps-riahub/).

Home page before and after:

Before:

<img width="600" alt="Screenshot 2025-03-15 at 5 09 02 PM" src="https://github.com/user-attachments/assets/36b111d7-3d7c-4be0-a713-4d0994d65171" />

After:

<img width="600" alt="Screenshot 2025-03-15 at 5 09 29 PM" src="https://github.com/user-attachments/assets/e226e27e-53db-48c3-b53e-c5d2d459d16a" />


RIA Hub page before and after:

Before:

<img width="600" alt="Screenshot 2025-03-15 at 5 10 40 PM" src="https://github.com/user-attachments/assets/7fa2f90f-25f3-47e3-8ec2-74d299566091" />

After:

<img width="600" alt="Screenshot 2025-03-15 at 5 10 52 PM" src="https://github.com/user-attachments/assets/f6ead19e-bbce-45e7-bdc6-08a516846e4e" />

Tips for testing:

This may be your first time testing a website PR, so you'll need to install and run the setup. To begin, ensure you have the following:

- [Hugo Extended v0.115+](https://gohugo.io/installation/)
- [Node v18+](https://nodejs.org/en/download/)
- [Go v1.20+](https://go.dev/doc/install)

Clone the repo:

```
git clone https://github.com/qoherent/qoherentwebsite.git
```

Then run the project setup and dependency installation commands:

```
npm run project-setup
```

and

```
npm install
```

Once all said and done, you'll be able to run the development server with:

```
npm run dev
```

And the local server should be accessible on `http://localhost:1313/`

Please let me know if you run into any issues!