### PR TITLE
fix: normalize README formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,12 @@
   "plugins": ["prettier-plugin-go-template"],
   "overrides": [
     {
+      "files": ["README.md"],
+      "options": {
+        "proseWrap": "always"
+      }
+    },
+    {
       "files": ["*.html"],
       "options": {
         "parser": "go-template",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Qoherent Website
 
-Qoherent's public website is a static Hugo site built with Tailwind CSS. Content is Markdown; Hugo templates and assets produce the files published to GitHub Pages.
+Qoherent's public website is a static Hugo site built with Tailwind CSS. Content
+is Markdown; Hugo templates and assets produce the files published to GitHub
+Pages.
 
 ## Requirements
 
@@ -48,25 +50,31 @@ npm run check
 - `themes/hugoplate/`: vendored base theme; do not add project changes here
 - `hugo.toml`: Hugo build and asset configuration
 
-Project files in `layouts/` and `assets/` override files at the same path in the vendored theme. Add new Qoherent behavior to the root directories so the theme can be updated independently.
+Project files in `layouts/` and `assets/` override files at the same path in the
+vendored theme. Add new Qoherent behavior to the root directories so the theme
+can be updated independently.
 
 ## Common Changes
 
 ### Edit a page
 
-Update the matching Markdown file in `content/english/pages/`. The front matter controls the title, description, draft state, and page image.
+Update the matching Markdown file in `content/english/pages/`. The front matter
+controls the title, description, draft state, and page image.
 
 ### Add a blog post
 
-Create a page bundle at `content/english/blog/<slug>/index.md`. Keep post images in the same directory and use descriptive alternative text.
+Create a page bundle at `content/english/blog/<slug>/index.md`. Keep post images
+in the same directory and use descriptive alternative text.
 
 ### Change navigation
 
-Edit `config/_default/menus.en.toml`. Menu entries must have visible labels and valid destinations.
+Edit `config/_default/menus.en.toml`. Menu entries must have visible labels and
+valid destinations.
 
 ### Change site settings
 
-Edit `config/_default/params.toml`. Do not hardcode service endpoints or credentials in templates.
+Edit `config/_default/params.toml`. Do not hardcode service endpoints or
+credentials in templates.
 
 ### Change styles or templates
 
@@ -75,14 +83,21 @@ Use root `assets/` and `layouts/`. Do not edit files under `themes/hugoplate/`.
 ## Image Rules
 
 - Use lowercase kebab-case filenames.
-- Do not add names that differ only by capitalization. Git treats those as distinct files, but default macOS filesystems do not.
+- Do not add names that differ only by capitalization. Git treats those as
+  distinct files, but default macOS filesystems do not.
 - Resize source images to the largest size used by the site.
-- Use descriptive alt text for informative images and empty alt text only for decorative images.
+- Use descriptive alt text for informative images and empty alt text only for
+  decorative images.
 
 ## Validation
 
-`npm run check` creates an unminified local build in `.hugo-validation/`, validates generated HTML, checks internal links and fragments, checks critical Markdown rules, and runs the npm security audit.
+`npm run check` creates an unminified local build in `.hugo-validation/`,
+validates generated HTML, checks internal links and fragments, checks critical
+Markdown rules, and runs the npm security audit.
 
-See `docs/quality-baseline.md` for the legacy HTML rules that remain deferred until the content redesign.
+See `docs/quality-baseline.md` for the legacy HTML rules that remain deferred
+until the content redesign.
 
-The production workflow in `.github/workflows/main.yml` installs dependencies with `npm ci`, builds with the pinned Hugo version, and publishes the generated artifact.
+The production workflow in `.github/workflows/main.yml` installs dependencies
+with `npm ci`, builds with the pinned Hugo version, and publishes the generated
+artifact.


### PR DESCRIPTION
## Summary
- make README prose wrapping explicit in Prettier configuration
- format README into a platform-independent canonical form
- fix the Linux-only `prettier --check .` deployment failure

## Validation
- `npm run check`
- `npm run build`
- Prettier 3.9.6 under Node 24

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update makes README prose wrapping deterministic by applying `proseWrap: "always"` only to `README.md` and reformatting the document accordingly.

Prettier 3.9.6 accepted the updated configuration, the README and configuration passed focused formatting checks, and formatting the README again produced byte-identical output. A representative HTML template also continued to pass using the existing go-template and HTML-specific configuration. The pre-change README does not satisfy the new wrapping policy, while the updated README does.

No defects were found. Safe to merge.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the formatting configuration works for the README and preserves the existing HTML formatting behavior.

Focused checks directly exercised the new README override, confirmed the updated README is already formatted, and confirmed formatting is idempotent.

**Files Needing Attention:** None. The changed `.prettierrc` and `README.md` were covered by focused validation.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Prettier check on the parent README using the PR configuration, and it exited with status 1 because the prose was not wrapped to the configured style.
- Updated the Prettier configuration and the README to Prettier 3.9.6, re-ran the checks, and confirmed that the parent README, the .prettierrc, and the README pass; the HTML go-template override also passes on a representative template, and formatting the README is byte-identical on re-run.
- Captured and reviewed the exact validation script execution from readme-prettier-script-capture.log to show the commands used during the run.

<a href="https://app.greptile.com/trex/runs/20398737/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: normalize README formatting"](https://github.com/qoherent/qoherentwebsite/commit/1a323ac55434a03aab56252c933c5ceb4085ab88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56301649)</sub>

<!-- /greptile_comment -->