### PR TITLE
ci: remove formatting check

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check:links": "start-server-and-test check:serve http://localhost:1314 \"linkinator http://localhost:1314 --recurse --check-fragments --skip '^(https?:)?//(?!localhost:1314)'\"",
     "check:markdown": "markdownlint-cli2 'content/**/*.md'",
     "check:format": "prettier --check .",
-    "check": "npm run check:format && npm run check:build && npm run check:html && npm run check:links && npm run check:markdown && npm audit --audit-level=moderate"
+    "check": "npm run check:build && npm run check:html && npm run check:links && npm run check:markdown && npm audit --audit-level=moderate"
   },
   "engines": {
     "node": ">=20.19.0"


### PR DESCRIPTION
## Summary
- remove the platform-inconsistent Prettier check from the CI validation chain
- keep build, HTML, link, Markdown, and audit validation enabled

## Validation
- `npm run check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The aggregate website validation command no longer runs the formatting check, while retaining the build, HTML, link, Markdown, and dependency-audit checks.

A controlled execution compared the previous and current command chains. The current chain invoked each retained check in order and completed successfully.

### T-Rex validation blocked

The full `npm run check` command could not complete because the Hugo tool is missing from PATH. It reached the build command and stopped with `hugo: not found` (exit 127).

<h3>Confidence Score: 5/5</h3>

Safe to merge: the retained aggregate validation commands remain correctly ordered and executable as a command chain.

No defects were found. The command composition was exercised in a controlled before-and-after run; the only limitation was the unavailable Hugo executable for the full site build.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The real runtime check was attempted from the repository root and halted when Hugo was not found on PATH (exit code 127).
- The controlled check harness was executed to compare the previous and current command chains; the previous chain ran build, HTML, links, Markdown, format, and audit, while the current chain ran build, HTML, links, Markdown, and audit and exited successfully.
- The check-chain-controlled.sh harness is the uploaded controlled-execution tool used for these tests, with no repository files changed.
- The results show that removing the formatting step does not disrupt the overall validation order, as the harness reports the same sequence behavior and a clean exit in the controlled run.

<a href="https://app.greptile.com/trex/runs/20410718/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: remove formatting check"](https://github.com/qoherent/qoherentwebsite/commit/8f1ca87b3c9154bc291fed4ff2e439013e1af012) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56325686)</sub>

<!-- /greptile_comment -->