### PR TITLE
fix: prevent logo carousel rendering artifacts

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -233,7 +233,6 @@
   width: 100%;
   max-height: 4rem;
   object-fit: contain;
-  filter: grayscale(1);
   opacity: 0.62;
   transition: opacity var(--motion-duration-base) ease;
 }


### PR DESCRIPTION
## Summary
- remove the grayscale filter from animated carousel logos
- preserve the existing subdued opacity styling
- avoid Linux Chromium rasterization artifacts during motion

## Verification
- npm run check:build
- npx prettier --check assets/scss/custom.scss
- git diff --check

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the grayscale filter from the animated ecosystem-logo carousel while preserving its sizing, opacity, clipping, transition, and scrolling behavior.

No defects were found.

## T-Rex validation blocked

The homepage was built successfully before and after the change, and Chromium confirmed unchanged carousel structure, card dimensions, opacity, animation state, and overflow behavior. Visual confirmation of the colored logo artwork and hover result was blocked because carousel images did not load in either browser capture (`imagesLoaded: false`, with the first image measured at 0×0px). Classification: service; the browser image-loading path did not provide the logo content needed for pixel-level validation.

<h3>Confidence Score: 5/5</h3>

The focused stylesheet update is safe to merge based on successful production builds and unchanged measured carousel layout and animation behavior.

No publishable defects were found. The comparison build and browser checks showed that the only computed-style change was removal of the grayscale filter; image content was unavailable in both captures, preventing a pixel-level confirmation of the intended visual result without indicating a defect.

**Files Needing Attention:** No files require changes. If visual confirmation is desired, retest the homepage where the carousel logo image resources are available to Chromium.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Built the baseline homepage with grayscale(1) and the updated homepage without that declaration using Hugo Extended 0.165.0, and produced production builds for both.
- Validated both builds in Chromium with an authored comparison script, which reported 18 logo cards, 208×120 card dimensions, opacity 0.62, object-fit: contain, a running marquee, and hidden viewport overflow, and observed the filter changing from grayscale(1) to none.
- Noted that logo images were unloaded in both browser captures, with imagesLoaded: false and the first image at 0×0px, preventing visual verification of color, image layout, and hover opacity.
- Reviewed the evidence and concluded that visual validation could not be completed due to unloading of carousel images, even though the production builds finished.

<a href="https://app.greptile.com/trex/runs/20413065/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: prevent logo carousel rendering art..."](https://github.com/qoherent/qoherentwebsite/commit/c71674e5f504a70017fe6037c442aab16ffae2a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56330738)</sub>

<!-- /greptile_comment -->